### PR TITLE
Load weights and tokenizer from .gguf

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -128,10 +128,10 @@ def dequantize_q4_0(tensor: gguf.ReaderTensor):
   return ((Tensor.cat(weights - (div * 16), div, dim=1).cast(dtypes.int8) - 8) * scales).reshape(np.flip(tensor.shape).tolist())
 
 def get_weight_and_scale_from_q4_0(tensor):
-    blocks = tensor.reshape(-1, 18)
-    weight = blocks[:, 2:]
-    scale = blocks[:, :2].view(np.float16)
-    return Tensor(weight), Tensor(scale)
+  blocks = tensor.reshape(-1, 18)
+  weight = blocks[:, 2:]
+  scale = blocks[:, :2].view(np.float16)
+  return Tensor(weight), Tensor(scale)
 
 def dequantize_q6_k(tensor: gguf.ReaderTensor):
   # https://github.com/ggerganov/llama.cpp/blob/master/ggml-quants.c#L2263

--- a/extra/models/llama.py
+++ b/extra/models/llama.py
@@ -99,11 +99,11 @@ class TransformerBlock:
     return (h + self.feed_forward(self.ffn_norm(h))).realize()
 
 class Transformer:
-  def __init__(self, dim:int, hidden_dim:int, n_heads:int, n_layers:int, norm_eps:float, vocab_size, linear=nn.Linear, n_kv_heads=None, rope_theta=10000, max_context=1024, jit=True, feed_forward=FeedForward):
+  def __init__(self, dim:int, hidden_dim:int, n_heads:int, n_layers:int, norm_eps:float, vocab_size, linear=nn.Linear, output_layer=nn.Linear, n_kv_heads=None, rope_theta=10000, max_context=1024, jit=True, feed_forward=FeedForward):
     self.layers = [TransformerBlock(dim, hidden_dim, n_heads, n_kv_heads, norm_eps, max_context, linear, feed_forward=feed_forward) for _ in range(n_layers)]
     self.norm = RMSNorm(dim, norm_eps)
     self.tok_embeddings = nn.Embedding(vocab_size, dim)
-    self.output = linear(dim, vocab_size, bias=False)
+    self.output = output_layer(dim, vocab_size, bias=False)
     self.max_context = max_context
     self.freqs_cis = precompute_freqs_cis(dim // n_heads, self.max_context * 2, rope_theta)
     self.forward_jit = TinyJit(self.forward) if jit else None

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(name='tinygrad',
             "librosa",
             "networkx",
             "hypothesis",
+            "protobuf==3.20.3"
         ]
       },
       include_package_data=True)

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ setup(name='tinygrad',
             "librosa",
             "networkx",
             "hypothesis",
-            "protobuf==3.20.3"
-            "gguf"
+            "protobuf==3.20.3",
+            "gguf",
         ]
       },
       include_package_data=True)

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(name='tinygrad',
             "networkx",
             "hypothesis",
             "protobuf==3.20.3"
+            "gguf"
         ]
       },
       include_package_data=True)


### PR DESCRIPTION
This commit adds support to load a llama model from a .gguf file. It also keeps the previous functionality and newer 4 bit quantification use. 